### PR TITLE
qt: enable the FFmpeg of Qt Multimedia

### DIFF
--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -202,6 +202,7 @@ class Qt < Formula
     cmake_args = std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST") + %w[
       -DFEATURE_pkg_config=ON
       -DINSTALL_MKSPECSDIR=share/qt/mkspecs
+      -DQT_FEATURE_ffmpeg=ON
       -DQT_FEATURE_webengine_proprietary_codecs=ON
       -DQT_FEATURE_webengine_kerberos=ON
       -DQT_ALLOW_SYMLINK_IN_PATHS=ON


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

FFmpeg backend is told to be the default for Qt6.6, but it isn't enabled here.

https://doc.qt.io/qt-6/qtmultimedia-index.html#ffmpeg-as-the-default-backend

The flag is here: https://github.com/qt/qtmultimedia/blob/3367b137e3aeec76b7edb7d14bde1a6cec7a64f4/src/plugins/multimedia/CMakeLists.txt#L4-L6

This change won't incur extra dependency because the QtWebengine already depends on FFmpeg.

The backend can used by apps by using.

```
export QT_MEDIA_BACKEND=ffmpeg
```

I want it mostly because it may support more formats,

Qt Multimedia's two backends macOS native and FFmpeg can co-exist in harmony.
