### PR TITLE
chezscheme: mark xterm as build depend

### DIFF
--- a/Formula/c/chezscheme.rb
+++ b/Formula/c/chezscheme.rb
@@ -16,7 +16,7 @@ class Chezscheme < Formula
   end
 
   depends_on "libx11" => :build
-  depends_on "xterm"
+  depends_on "xterm" => :build
   uses_from_macos "ncurses"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
chezscheme doesn't depend on xterm at runtime.

It is here because there is a hack, which uses a hard-coded path, to work around an ancient xterm bug.

Its failure doesn't even matter if not using xterm because `resize` only affects xterm. 

`SYSTEM("exec /usr/X11/bin/resize >& /dev/null");`

https://github.com/cisco/ChezScheme/blob/66c40f11423cf0718a0676b3cb09a0abd4990ec1/c/expeditor.c#L889-L897
